### PR TITLE
Pass through options to draft-js-import-element

### DIFF
--- a/src/stateFromMarkdown.js
+++ b/src/stateFromMarkdown.js
@@ -5,7 +5,7 @@ import {stateFromElement} from 'draft-js-import-element';
 
 import type {ContentState} from 'draft-js';
 
-export default function stateFromMarkdown(markdown: string): ContentState {
+export default function stateFromMarkdown(markdown: string, options?: object): ContentState {
   let element = MarkdownParser.parse(markdown, {getAST: true});
-  return stateFromElement(element);
+  return stateFromElement(element, options);
 }

--- a/src/stateFromMarkdown.js
+++ b/src/stateFromMarkdown.js
@@ -5,7 +5,7 @@ import {stateFromElement} from 'draft-js-import-element';
 
 import type {ContentState} from 'draft-js';
 
-export default function stateFromMarkdown(markdown: string, options?: object): ContentState {
+export default function stateFromMarkdown(markdown: string, options?: Object): ContentState {
   let element = MarkdownParser.parse(markdown, {getAST: true});
   return stateFromElement(element, options);
 }


### PR DESCRIPTION
It would be nice if we could pass options to the `BlockGenerator`. In my use case I wanted to create atomic blocks for images, so I had to set the `blockTypes` parameter.