### PR TITLE
Export Markdown parser

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,2 @@
 export {default as stateFromMarkdown} from './stateFromMarkdown';
+export {default as MarkdownParser} from './MarkdownParser';


### PR DESCRIPTION
When I export Markdown from `react-rte` and render it again in `marked`,
I see some of the literal characters used in the exported markdown.
Underlines being one key example I need to support. `marked` renders 
them as `++some text++`, although `react-rte` underlines the text
appropriately. Reading their code, I see they use this package, but 
I can't access the specific parser they use to make things work.

Rather than override the lexer/parser again and manually track what RTE
is doing, I'd rather export the parser here so that users can automatically
follow along with any changes to the parser rules.

If there's an alternative solution, please let me know.